### PR TITLE
Custom measure formatting

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.0
+
+- Added a custom formatter argument that can be passed into the `Measure.in` and `Measure.toString` methods.
+
 ## v1.0.0
 
 - Changed all interface names to no longer be I- prefixed.

--- a/docs/measures.md
+++ b/docs/measures.md
@@ -327,11 +327,22 @@ Symbols are used in converting other measures into strings as can be seen below.
 ### Formatting
 
 ```ts
-Measure<U>.toString(): string;
-Measure<U>.in(unit: Measure<U>): string;
+Measure<U>.toString(formatter?: MeasureFormatter): string;
+Measure<U>.in(unit: Measure<U>, formatter?: MeasureFormatter): string;
 ```
 
 The first method, `toString`, creates a string version of the unit, ignoring any [symbol](#symbols) information on that measure. The second method, `in`, will format a given unit as if it is given in units of the second measure, assuming the second measure has a symbol. If not, this is equivalent to calling `toString()`.
+
+Both methods may optionally be passed a formatter which has the following interface:
+
+```ts
+interface MeasureFormatter {
+    formatValue?: (value: number) => string;
+    formatUnit?: (unit: UnitWithSymbols) => string;
+}
+```
+
+The `formatValue` function, if provided, will be applied to customize the formatting of the numeric value of the measure in the resulting string. The `formatUnit`, if provided, will be passed the unit of the measure in order to customize how that is formatted. When calling the `Measure.in` method, the `formatUnit` function will only be used if the unit being used to express the measure has no symbol.
 
 *Examples:*
 
@@ -343,10 +354,17 @@ const distance = Measure.of(5, kilometers);
 console.log(distance.toString()); // 5000 m
 console.log(distance.in(kilometers)); // 5 km
 console.log(kilometers.in(kilometers)); // 1 km
+console.log(distance.toString({
+   formatValue: x => x.toExponential(),
+   formatUnit: () => "meters",
+})); // 5e+3 meters
 
 const force = Measure.of(30, newtons);
 console.log(force.toString()); // 30 kg * m * s^-2
 console.log(force.in(newtons)); // 30 N
+console.log(force.in(newtons, {
+   formatValue: x => x.toPrecision(5),
+})); // 30.000 N
 ```
 
 ### Unsafe Mappings

--- a/src/measure/__test__/numberMeasureTests.ts
+++ b/src/measure/__test__/numberMeasureTests.ts
@@ -304,13 +304,13 @@ describe("Number measures", () => {
         });
 
         it("should format measures as other measures with symbols", () => {
-            const glorbs = Measure.of(100, meters, "glb");
-            expect(Measure.of(1000, meters).in(glorbs)).toBe("10 glb");
+            const kilometers = Measure.of(1000, meters, "km");
+            expect(Measure.of(10000, meters).in(kilometers)).toBe("10 km");
         });
 
         it("should use normal formatting if the other measure has no symbol", () => {
-            const glorbs = Measure.of(100, meters);
-            expect(Measure.of(1000, meters).in(glorbs)).toBe("1000 m");
+            const kilometers = Measure.of(1000, meters);
+            expect(Measure.of(1000, meters).in(kilometers)).toBe("1000 m");
         });
 
         it("should use base unit symbols to format when available", () => {
@@ -341,22 +341,22 @@ describe("Number measures", () => {
         });
 
         it("should not use a custom formatter for units when expressing in terms of another measure", () => {
-            const glorbs = Measure.of(100, meters, "glb");
+            const kilometers = Measure.of(1000, meters, "km");
             expect(
-                Measure.of(20, glorbs).in(glorbs, {
+                Measure.of(20, kilometers).in(kilometers, {
                     formatValue: value => value.toExponential(),
-                    formatUnit: () => "glorbs",
+                    formatUnit: () => "kilometers",
                 }),
-            ).toBe("2e+1 glb");
+            ).toBe("2e+1 km");
         });
 
         it("should use a custom formatter for units when expressing in terms of another unit with no symbol", () => {
-            const glorbs = Measure.of(100, meters);
+            const kilometers = Measure.of(1000, meters);
             expect(
-                Measure.of(20, glorbs).in(glorbs, {
-                    formatUnit: () => "glorbs",
+                Measure.of(20, kilometers).in(kilometers, {
+                    formatUnit: () => "meters",
                 }),
-            ).toBe("2000 glorbs");
+            ).toBe("20000 meters");
         });
     });
 

--- a/src/measure/format.ts
+++ b/src/measure/format.ts
@@ -1,7 +1,7 @@
 import { getExponentValue, negateExponent } from "../exponent/exponentValueArithmetic";
 import { SymbolAndExponent, UnitWithSymbols } from "./unitTypeArithmetic";
 
-export function formatUnit(unit: UnitWithSymbols): string {
+export function defaultFormatUnit(unit: UnitWithSymbols): string {
     const dimensions = Object.keys(unit)
         .map(dimension => unit[dimension])
         .filter(isDimensionPresent)

--- a/src/measure/genericMeasure.ts
+++ b/src/measure/genericMeasure.ts
@@ -9,6 +9,11 @@ import {
     UnitWithSymbols,
 } from "./unitTypeArithmetic";
 
+export interface MeasureFormatter<N> {
+    formatValue?: (value: N) => string;
+    formatUnit?: (unit: UnitWithSymbols) => string;
+}
+
 /** The set of numeric operations required to fully represent a `GenericMeasure` for a given numeric type */
 export interface NumericOperations<N> {
     /** Returns the multiplicative identity for numbers of type N */
@@ -189,7 +194,7 @@ export interface GenericMeasure<N, U extends Unit> {
      * Formats the value and the unit.
      * @returns a string representation of measure
      */
-    toString(): string;
+    toString(formatter?: MeasureFormatter<N>): string;
 
     /**
      * Formats this measure as a product of another unit. If the given unit has a symbol, this will format as a number
@@ -197,7 +202,7 @@ export interface GenericMeasure<N, U extends Unit> {
      * @param a unit to be used to represent this measure
      * @returns a string representation of measure
      */
-    in(unit: GenericMeasure<N, U>): string;
+    in(unit: GenericMeasure<N, U>, formatter?: MeasureFormatter<N>): string;
 
     /**
      * Adds a symbol to this measure.


### PR DESCRIPTION
Fixes https://github.com/jscheiny/safe-units/issues/140

Introduces an optional extra argument to `toString` and `in` methods of measures which is a formatter that allows optionally formatting each of the value and unit of the measure.