### PR TITLE
Fix type NonZeroExponent: Zero was not excluded

### DIFF
--- a/src/exponent/exponentTypeArithmetic.ts
+++ b/src/exponent/exponentTypeArithmetic.ts
@@ -3,7 +3,7 @@ import { DivideExponents } from "./generated/division";
 import { Exponent } from "./generated/exponent";
 import { MultiplyExponents } from "./generated/multiplication";
 
-export type NonZeroExponent = Exclude<Exponent, 0>;
+export type NonZeroExponent = Exclude<Exponent, "0">;
 
 export type SubtractExponents<L extends Exponent, R extends Exponent> = AddExponents<L, Negative<R>>;
 


### PR DESCRIPTION
because zero is represented by the string literal (type) "0", not by the
number literal (type) 0.