### PR TITLE
add valueIn (fixes jscheiny/safe-units#163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ const megaFurlongsPerMicroFortnight = mega(furlongs)
 console.log(speedOfLight.in(megaFurlongsPerMicroFortnight)); // 1.8026174997852542 Mfur/µftn
 ```
 
+### Converting units for external use
+```typescript
+const distanceInFurlongs: number = Measure.of(2, miles).valueIn(furlongs); // 16
+```
 ### Deriving quantities
 
 ```typescript

--- a/codegen/emit.ts
+++ b/codegen/emit.ts
@@ -1,4 +1,4 @@
-import { exists, mkdir, writeFile } from "fs";
+import { mkdir, writeFile } from "fs";
 import { OperatorSpec } from "./common";
 import { genExponentType } from "./genExponent";
 import { genOperatorTests } from "./genTests";
@@ -36,7 +36,10 @@ function getOperatorEmitPlans(prefix: string, genSource: (spec: OperatorSpec) =>
     return operators.map(operator => {
         const operatorSpec: OperatorSpec = { ...operator, ...common };
         const { fileNamePrefix } = operator;
-        return { path: `${prefix}/${fileNamePrefix}.ts`, source: genSource(operatorSpec) };
+        return {
+            path: `${prefix}/${fileNamePrefix}.ts`,
+            source: genSource(operatorSpec),
+        };
     });
 }
 
@@ -45,17 +48,9 @@ function prepForEmit(callback: () => void): void {
 }
 
 function makeDirectory(path: string, callback: () => void): void {
-    exists(path, doesExist => {
-        if (doesExist) {
-            return callback();
-        }
-        mkdir(path, err => {
-            if (err) {
-                console.error(`There was an error creating directory ${path}`);
-            } else {
-                callback();
-            }
-        });
+    mkdir(path, err => {
+        if (!err || err.code === "EEXIST") callback();
+        else console.error(`There was an error creating directory ${path}`);
     });
 }
 

--- a/docs/measures.md
+++ b/docs/measures.md
@@ -412,6 +412,18 @@ elapsed.in(minutes); // 1 min
 rate.in(poundsPerSecond); // 1 £/s
 ```
 
+## Conversions
+
+In case we need to get numeric value of our measure in some particular unit, e.g. for passing to an external API, the `valueIn` method can be used, which returns a number:
+
+```ts
+const poundsPerSecond: CashFlowRate = pounds.per(seconds).withSymbol("£/s");
+
+profit.valueIn(pounds); // 60
+elapsed.valueIn(minutes); // 1
+rate.valueIn(poundsPerSecond); // 1
+```
+
 ## Function Wrappers
 
 It is often desirable to convert operations on numbers into operations on measures. Frequently, these functions make no change on the unit of a value. For example, suppose we want to make an absolute value function that operates on measures. We'd expect the function perserve the unit of the input. We can simply wrap an existing absolute value function using `wrapUnaryFn`:

--- a/docsgen/sidebar.tsx
+++ b/docsgen/sidebar.tsx
@@ -10,14 +10,16 @@ interface SidebarProps {
 }
 
 export const Sidebar: React.FunctionComponent<SidebarProps> = ({ pages, selectedIndex }) => {
-    const pageSections = pages[selectedIndex].sections.filter(({ level }) => level <= 3).map(({ id, node, level }) => {
-        const className = classes(level === 2 && section, level === 3 && subsection);
-        return (
-            <SectionLink key={id} href={`#${id}`} className={className}>
-                <MarkdownChildren root={node} />
-            </SectionLink>
-        );
-    });
+    const pageSections = pages[selectedIndex].sections
+        .filter(({ level }) => level <= 3)
+        .map(({ id, node, level }) => {
+            const className = classes(level === 2 && section, level === 3 && subsection);
+            return (
+                <SectionLink key={id} href={`#${id}`} className={className}>
+                    <MarkdownChildren root={node} />
+                </SectionLink>
+            );
+        });
 
     const links = pages.map((page, index) => {
         const isSelected = index === selectedIndex;

--- a/src/measure/__test__/numberMeasureTests.ts
+++ b/src/measure/__test__/numberMeasureTests.ts
@@ -1,3 +1,4 @@
+import { feet, kilo } from "../..";
 import { MeasureFormatter } from "../genericMeasure";
 import { Measure } from "../numberMeasure";
 
@@ -357,6 +358,16 @@ describe("Number measures", () => {
                     formatUnit: () => "meters",
                 }),
             ).toBe("20000 meters");
+        });
+    });
+
+    describe("conversion", () => {
+        it("should calculate meters to kilometers correctly", () => {
+            expect(Measure.of(10000, meters).valueIn(kilo(meters))).toBe(10);
+        });
+
+        it("should calculate feet to meters correctly", () => {
+            expect(Measure.of(10, feet).valueIn(meters)).toBeCloseTo(3.048);
         });
     });
 

--- a/src/measure/genericMeasure.ts
+++ b/src/measure/genericMeasure.ts
@@ -205,6 +205,13 @@ export interface GenericMeasure<N, U extends Unit> {
     in(unit: GenericMeasure<N, U>, formatter?: MeasureFormatter<N>): string;
 
     /**
+     * Converts this measure to another unit, e.g. for passing to an external API that requires pure numbers of particular unit.
+     * @param unit the unit to convert to
+     * @returns the numeric value of this measure in the given unit
+     */
+    valueIn(unit: GenericMeasure<N, U>): N;
+
+    /**
      * Adds a symbol to this measure.
      * @param symbol the symbol of the unit represented by this measure
      */

--- a/src/measure/genericMeasureClass.ts
+++ b/src/measure/genericMeasureClass.ts
@@ -147,6 +147,10 @@ export function createMeasureClass<N>(num: NumericOperations<N>): GenericMeasure
             return `${value} ${unit.symbol}`;
         }
 
+        public valueIn(unit: GenericMeasure<N, U>): N {
+            return this.over(unit).value;
+        }
+
         public withSymbol(symbol: string | undefined): GenericMeasure<N, U> {
             return new Measure(this.value, this.unit, symbol);
         }

--- a/src/measure/unitTypeArithmetic.ts
+++ b/src/measure/unitTypeArithmetic.ts
@@ -36,7 +36,9 @@ export type DivideUnits<L extends Unit, R extends DivisorUnit<L>> = CleanUnit<
 >;
 
 /** A type that is assignable from all units that U can be divided by without producing an error. */
-export type DivisorUnit<U extends Unit> = Partial<{ [D in keyof U]: SubtrahendOf<CleanExponent<U[D]>> }> & Unit;
+export type DivisorUnit<U extends Unit> = 
+    | U // unit can always be divided by itself, but typescript doesn't quite figure that out
+    | Partial<{ [D in keyof U]: SubtrahendOf<CleanExponent<U[D]>> }> & Unit;
 
 // Exponentiation
 

--- a/test/types/measures.ts
+++ b/test/types/measures.ts
@@ -1,4 +1,13 @@
-import { Acceleration, Area, kilograms, Measure, meters, newtons, seconds, Volume } from "safe-units";
+import {
+  Acceleration,
+  Area,
+  kilograms,
+  Measure,
+  meters,
+  newtons,
+  seconds,
+  Volume,
+} from "safe-units";
 
 // Valid usages
 

--- a/test/types/units.ts
+++ b/test/types/units.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src/measure/unitTypeArithmetic";
 import { IsSame } from "./utils";
 import { IsSingleStringLiteral } from "../../src/measure/typeUtils";
+import { Measure, meters, milli, seconds } from "safe-units";
 
 type Extends<A, B> = A extends B ? true : false;
 
@@ -63,3 +64,8 @@ type RadicandRejectsZero = RadicandUnit<"0">; // $ExpectError
 type SingleLiteralWorks = IsSingleStringLiteral<"A">; // $ExpectType true
 type UnionLiteralWorks = IsSingleStringLiteral<"A" | "B">; // $ExpectType false
 type StringTypeWorks = IsSingleStringLiteral<string>; // $ExpectType false
+
+// Conversion
+
+Measure.of(3, meters).valueIn(seconds); // $ExpectError
+Measure.of(3, meters).valueIn(milli(meters)); // $ExpectType number


### PR DESCRIPTION
 * Added the `valueIn` method I suggested, 
 * fixed some things that `npm run verify` complained about:
   * some formatting
   * removed usage of deprecated `exists` method.