### PR TITLE
Add esm build and package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,20 @@
         "type": "git",
         "url": "https://github.com/jscheiny/safe-units.git"
     },
-    "main": "dist/src/index.js",
-    "typings": "dist/src/index.d.ts",
+    "main": "./dist/cjs/index.js",
+    "module": "./dist/esm/index.js",
+    "types": "./dist/types/index.d.ts",
+    "exports": {
+        "import": "./dist/esm/index.js",
+        "require": "./dist/cjs/index.js"
+    },
+    "files": [
+        "dist"
+    ],
     "scripts": {
-        "build": "tsc -p src",
+        "build:cjs": "tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+        "build:esm": "tsc -p tsconfig.esm.json && echo '{\"type\":\"module\"}' > dist/esm/package.json",
+        "build": "yarn run build:cjs && yarn run build:esm",
         "clean": "rimraf dist docs/build",
         "compile:docs": "tsc -p docsgen",
         "compile:examples": "tsc -p docs/examples",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
         "moduleResolution": "node",
+        "declaration": true,
+        "declarationDir": "./dist/types",
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,
@@ -18,5 +19,13 @@
             "es2015",
             "es2015.core"
         ]
-    }
+    },
+    "include": [
+        "src"
+    ],
+    "exclude": [
+        "dist",
+        "node_modules",
+        "test"
+    ]
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "module": "commonjs",
+        "outDir": "./dist/cjs",
+        "target": "ES2015"
+    }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "module": "es6",
+        "outDir": "./dist/esm",
+        "target": "es6"
+    }
+}


### PR DESCRIPTION
Resolves #199.

## Description

This change adds a `tsconfig.cjs.json` and `tsconfig.esm.json`, both extending a common `tsconfig.base.json`, which will allow the project to generate two separate builds to distribute. Within `package.json` the old `module` property and newer `exports` property will allow downstream consumers to automatically use the build which is compatible with their tooling. This was mainly prepared following this guide: https://blog.mastykarz.nl/create-npm-package-commonjs-esm-typescript/

The `build:cjs` and `build:esm` npm commands are used to generate each build and place a minimal `package.json` in each folder to avoid needing to use the `.mjs` extension on the files in the `esm` build. See https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html "Per ESM/CJS package.json" for more detail.

## Testing

I created two minimal projects to test these changes, a commonjs project and an esm project with a minimal entry file:

```js
import { grams, kilo, Measure } from 'safe-units';

const m = Measure.of(123, grams);

console.log(m.valueIn(kilo(grams)));
```

Both projects use Rollup to create a bundle, which I measured for size. I built each project twice, once with `"safe-units": "^2.0.1"` from npm, and once with `"safe-units": "../safe-units"` to build with my local version of the module.

### Results

CommonJS project with `safe-units` from npm: index.js 48K
CommonJS project with `safe-units` from this branch: index.js 48K

ESM project with `safe-units` from npm: index.js 48K
ESM project with `safe-units` from this branch: index.js **24K**

As a side note, even in the ESM project I couldn't build the bundle without the `@rollup/plugin-commonjs` module, but this was no longer necessary when building from this branch, since a native esm module is now available.

