### PR TITLE
Fix compilation of `docsgen`, `examples`, and type tests

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,13 +19,5 @@
             "es2015",
             "es2015.core"
         ]
-    },
-    "include": [
-        "src"
-    ],
-    "exclude": [
-        "dist",
-        "node_modules",
-        "test"
-    ]
+    }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,5 +1,5 @@
 {
-    "extends": "./tsconfig.base.json",
+    "extends": "./tsconfig.src.base.json",
     "compilerOptions": {
         "module": "commonjs",
         "outDir": "./dist/cjs",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,5 +1,5 @@
 {
-    "extends": "./tsconfig.base.json",
+    "extends": "./tsconfig.src.base.json",
     "compilerOptions": {
         "module": "es6",
         "outDir": "./dist/esm",

--- a/tsconfig.src.base.json
+++ b/tsconfig.src.base.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "test"
+  ]
+}


### PR DESCRIPTION
Fixes #209

`docsgen/tsconfig.json`, `docs/examples/tsconfig.json` and `tests/tsconfig.json` all reference `tsconfig.base.json`, which specified  `include` and `exclude` arrays that were intended for the primary project. As a result, those projects were actually building the library's code instead of their own (if you delete `dist/docsgen` and then run `yarn verify` on the current main branch, it will fail because `dist/docsgen` contains the wrong thing).

This PR fixes this by extracting the `include` and `exclude` fields from `tsconfig.base.json` into a new `tsconfig.src.base.json` file that is only referenced by `tsconfig.cjs.json` and `tsconfig.esm.json`.